### PR TITLE
fix typos

### DIFF
--- a/docs/about/purpose.rst
+++ b/docs/about/purpose.rst
@@ -3,6 +3,6 @@ Purpose
 =======
 
 Personal financial management is pretty difficult, and everybody has their own approach to it. Some people make budgets, other people limit their cashflow by throwing away their credit cards, 
-others try to increase their current cashflow. There are tons of ways to save and earn money. Firefly III works on the principle that if you know where you're money is going, you can stop it from going there.
+others try to increase their current cashflow. There are tons of ways to save and earn money. Firefly III works on the principle that if you know where your money is going, you can stop it from going there.
 
 By keeping track of your expenses and your income you can budget accordingly and save money. Stop living from paycheck to paycheck but give yourself the financial wiggle room you need.

--- a/docs/advanced/links.rst
+++ b/docs/advanced/links.rst
@@ -26,7 +26,7 @@ In Firefly III you can store these links between transactions. By default, four 
 * Is reimbursed by
 * Relates to
 
-These links work both ways. When transaction A is be refunded by transaction B, B is noted to refund A.
+These links work both ways. When transaction A is been refunded by transaction B, B is noted to refund A.
 
 .. graphviz::
 

--- a/docs/advanced/links.rst
+++ b/docs/advanced/links.rst
@@ -26,7 +26,7 @@ In Firefly III you can store these links between transactions. By default, four 
 * Is reimbursed by
 * Relates to
 
-These links work both ways. When transaction A is been refunded by transaction B, B is noted to refund A.
+These links work both ways. When transaction A has been refunded by transaction B, B is noted to refund A.
 
 .. graphviz::
 

--- a/docs/advanced/splits.rst
+++ b/docs/advanced/splits.rst
@@ -57,7 +57,7 @@ Likewise, your salary may have multiple components. Your have a base salary. But
 Any time you create a deposit, transfer or a withdrawal, Firefly III allows you to **split** a transaction into multiple parts. When you do this, you can:
 
 - Assign part of an expense to a budget;
-- Assign different revenue accounts to parts of of a deposit.
+- Assign different revenue accounts to parts of a deposit.
 - Categorize money differently.
 
 You can split your entire groceries-receipt into small "sub"-transactions, or you can specify each component of your salary. There are many more examples to think of.

--- a/docs/api/start.rst
+++ b/docs/api/start.rst
@@ -46,7 +46,7 @@ System errors are represented using the following notation. All errors are in En
    }
 
 
-Of course, when debug is *disabled* this error will be not be very descriptive:
+Of course, when debug is *disabled* this error will not be very descriptive:
 
 .. code-block:: json
    

--- a/docs/concepts/transactions.rst
+++ b/docs/concepts/transactions.rst
@@ -65,7 +65,7 @@ In Firefly III and most other systems this is stored using a "`double-entry book
 
 Each transaction is stored twice. Once as a loss (for one party), and once as a profit (for the other party). This seems pretty pointless, and technically it is. But it was designed back when clerks could be fraudulent and this double-entry system stopped fraud. In these modern days it is useful to check if all records are straight.
 
-It is also useful when transferring money back and forth between your own :ref:`accounts <accounts>`. This is the same as spending money. It's all moving money around. This helps maintaining the internal consistency of the database.
+It is also useful when transferring money back and forth between your own :ref:`accounts <accounts>`. This is the same as spending money. It's all moving money around. This helps maintain the internal consistency of the database.
 
 Transactions have a few useful fields:
 
@@ -126,7 +126,7 @@ Likewise, your salary may have multiple components. Your base salary may be 1200
 Any time you create a deposit, transfer or a withdrawal, Firefly III allows you to **split** a transaction into multiple parts. When you do this, you can:
 
 - Assign part of an expense to a budget;
-- Assign different revenue accounts to parts of of a deposit.
+- Assign different revenue accounts to parts of a deposit.
 - Categorize money differently.
 
 You can split your entire groceries-receipt into small "sub"-transactions. You can specify each component of your salary.

--- a/docs/support/faq.rst
+++ b/docs/support/faq.rst
@@ -91,7 +91,7 @@ Then you are ready to install the database in PostgreSQL:
 I see a white page and nothing else?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Check out the log files in ``storage/logs`` to see what is going on. Please open a ticker if you are not sure what to do. If the logs are empty  Firefly III cannot write to them. Make sure that the web server has write access to this directory. If the logs still remain empty, do you have a the ``vendor`` directory in your Firefly III root? If not, run the Composer commands.
+Check out the log files in ``storage/logs`` to see what is going on. Please open a ticker if you are not sure what to do. If the logs are empty  Firefly III cannot write to them. Make sure that the web server has write access to this directory. If the logs still remain empty, do you have a ``vendor`` directory in your Firefly III root? If not, run the Composer commands.
 
 I get a 404?
 ~~~~~~~~~~~~


### PR DESCRIPTION
([Second time](https://github.com/Findus23/docs/commit/cb9b158f15bf419004bf865bad12f593c7416d1f), as Atom and Vim think they have to remove all trailing spaces on save)

Just a few minor fixes found with [languagetool](https://languagetool.org/).