### PR TITLE
Changes upgrade instructions

### DIFF
--- a/docs/installation/docker.rst
+++ b/docs/installation/docker.rst
@@ -151,10 +151,10 @@ To update the container just run ``docker-compose pull firefly_iii_app && docker
 
 .. code-block:: bash
 
-   docker exec -it <container> php artisan migrate
-   docker exec -it <container> php artisan firefly:upgrade-database
-   docker exec -it <container> php artisan firefly:verify
-   docker exec -it <container> php artisan passport:install
+    docker-compose exec -T firefly_iii_app php artisan migrate
+    docker-compose exec -T firefly_iii_app php artisan firefly:upgrade-database
+    docker-compose exec -T firefly_iii_app php artisan firefly:verify
+    docker-compose exec -T firefly_iii_app php artisan passport:install
 
 If you're having trouble with (parts of) this step, please check out the :ref:`Docker FAQ <faqdocker>`
 


### PR DESCRIPTION
In the situation where you are using `docker-compose` you can use `docker-compose exec` to use the running app container. This method was already used for initialising, but in the upgrade instructions there was still references to using `docker exec`. 

The new instructions are more consistent with the initialising and a bit less complicated as you don't need to find out the container name.