### PR TITLE
Clarified environment variable name

### DIFF
--- a/docs/installation/docker.rst
+++ b/docs/installation/docker.rst
@@ -44,7 +44,7 @@ Run this Docker command to start the Firefly III container. Make sure that you e
    -e FF_DB_PASSWORD=CHANGEME \
    jc5x/firefly-iii:latest
 
-Firefly III assumes MySQL. If you use Postgres, add the following environment variable to the command: ``DB_CONNECTION=pgsql``. To read more about the environment variables, scroll down below.
+Firefly III assumes MySQL. If you use Postgres, add the following environment variable to the command: ``FF_DB_CONNECTION=pgsql``. To read more about the environment variables, scroll down below.
 
 When executed this command will fire up a Docker container with Firefly III inside of it. It may take some time to start.
 


### PR DESCRIPTION
I think both the old and the new versions are _technically correct_, as the setting is actually called ``DB_CONNECTION`` in the env file. 

That said, listing the environment variable name needed for the ``docker run`` command makes the instructions clearer in my opinion.