### PR TITLE
Added warning, improved info, and fixed markup

### DIFF
--- a/docs/installation/backup.rst
+++ b/docs/installation/backup.rst
@@ -9,16 +9,22 @@ If you want to make a backup of all your data, make sure you grab the following:
 - All uploads from ``/storage/uploads``;
 - Any exports from ``/storage/export``.
 
-If you're running Firefly III in a container such as Docker, make sure you grab:
+------
+Docker
+------
+
+If you're running Firefly III in Docker, make sure you grab:
 
 - The 3 volumes used by Firefly: "upload", "export" and "db"
 - The Docker variables you've used to launch the container, and especially the ``APP_ENV``-variable.
 
 That way you have everything you need in case of problems.
 
-For example, with Docker:
+For example, to backup the database volume in Docker:
 
 - backup with ``docker run --rm -v "firefly_iii_db:/tmp" -v "$HOME/backups/firefly:/backup" ubuntu tar -czvf /backup/firefly_db.tar /tmp``
 - restore with ``docker run --rm -v "firefly_iii_db:/recover" -v "$HOME/backups/firefly:/backup" ubuntu tar -xvf /backup/firefly_db.tar -C /recover --strip 1``
 
-To get a better idea of how this works, see Docker's [official documentation](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes).
+A word of caution: Check that the volume exists **BEFORE** trying to back it up! If a named volume doesn't exist docker will create an empty one, and the command will backup that empty volume - *wiping out the existing backup*.
+
+To get a better idea of how this works, see Docker's `official documentation <https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes>`_.

--- a/docs/installation/backup.rst
+++ b/docs/installation/backup.rst
@@ -20,11 +20,11 @@ If you're running Firefly III in Docker, make sure you grab:
 
 That way you have everything you need in case of problems.
 
-For example, to backup the database volume in Docker:
+For example, to backup the database volume:
 
 - backup with ``docker run --rm -v "firefly_iii_db:/tmp" -v "$HOME/backups/firefly:/backup" ubuntu tar -czvf /backup/firefly_db.tar /tmp``
 - restore with ``docker run --rm -v "firefly_iii_db:/recover" -v "$HOME/backups/firefly:/backup" ubuntu tar -xvf /backup/firefly_db.tar -C /recover --strip 1``
 
-A word of caution: Check that the volume exists **BEFORE** trying to back it up! If a named volume doesn't exist docker will create an empty one, and the command will backup that empty volume - *wiping out the existing backup*.
+A word of caution: Check that the volume exists **BEFORE** trying to back it up! If a named volume doesn't exist Docker will create an empty one, and the command will backup that empty volume - *wiping out the existing backup*.
 
 To get a better idea of how this works, see Docker's `official documentation <https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes>`_.


### PR DESCRIPTION
- I've learned that docker silently creates volumes if they don't exist. That's bad if we only want to back up existing things.
- It wasn't clear that the commands only work for one volume at a time.
- Fixed a link that was formatted for markdown, not rst.
