### PR TITLE
Let the docs reflect the new minimum PHP version 7.3

### DIFF
--- a/docs/installation/server.rst
+++ b/docs/installation/server.rst
@@ -11,11 +11,11 @@ If you have your own (virtual) web server you can use this guide to install Fire
 
 Ingredients
 -----------
-You need a working LAMP, LEMP or WAMP stack. If you don't have one, search the web to find out how to get one. Make sure you're running PHP 7.2. There are many tutorials that will help you install one. Here are some Google queries to help you.
+You need a working LAMP, LEMP or WAMP stack. If you don't have one, search the web to find out how to get one. Make sure you're running PHP 7.3. There are many tutorials that will help you install one. Here are some Google queries to help you.
 
-1. `Install a LAMP stack with PHP 7.2 <https://www.google.com/search?q=lamp+stack+php+7.2>`_
-2. `Upgrade Ubuntu PHP 7.2 <https://www.google.com/search?q=upgrade+ubuntu+php+7.2>`_
-3. `PHP 7.2 raspberry pi <https://www.google.nl/search?q=PHP+7.2+raspberry+pi>`_
+1. `Install a LAMP stack with PHP 7.3 <https://www.google.com/search?q=lamp+stack+php+7.3>`_
+2. `Upgrade Ubuntu PHP 7.3 <https://www.google.com/search?q=upgrade+ubuntu+php+7.3>`_
+3. `PHP 7.3 raspberry pi <https://www.google.nl/search?q=PHP+7.3+raspberry+pi>`_
 
 If you wish to use another database such as SQLite or Postgres, please check out the :ref:`Server FAQ <faqselfhosted>`.
 
@@ -23,9 +23,9 @@ You need a (MySQL) database and credentials for a user that can access that data
 
 Several users have created specific guides for their OS and database combination
 
-1. `CentOS 7, with nginx and PHP 7.2 <https://old.reddit.com/r/FireflyIII/comments/825n4l/centos_7_nginx_installation_guide/>`_
-2. `Ubuntu Server 16.04LTS with nginx and PHP 7.2 <https://old.reddit.com/r/FireflyIII/comments/8thxuu/fireflyiii_on_ubuntu_server_1604lts_nginx_php72/>`_
-3. `Ubuntu Server 18.04 with nginx and PHP 7.2 <https://gist.github.com/philthynz/ec04833a8e39c7f7d1b0d33cb4197a95>`_
+1. `CentOS 7, with nginx and PHP 7.3 <https://old.reddit.com/r/FireflyIII/comments/825n4l/centos_7_nginx_installation_guide/>`_
+2. `Ubuntu Server 16.04LTS with nginx and PHP 7.3 <https://old.reddit.com/r/FireflyIII/comments/8thxuu/fireflyiii_on_ubuntu_server_1604lts_nginx_php72/>`_
+3. `Ubuntu Server 18.04 with nginx and PHP 7.3 <https://gist.github.com/philthynz/ec04833a8e39c7f7d1b0d33cb4197a95>`_
 4. `Ubuntu Server 18.04 with nginx, PHP 7.3 and a Let's Encrypt certificate <https://gist.github.com/optimistic5/ca5a4a8593dcdb7360f712d37a0cc657>`_
 5. `Raspberry Pi 3, with Docker and Docker compose <https://gist.github.com/josephbadow/588c2ae961231fe338c459127c7d835b>`_
 

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -95,13 +95,14 @@ If you get 500 errors or other problems, you may have to set the correct access 
    sudo chown -R www-data:www-data firefly-iii
    sudo chmod -R 775 firefly-iii/storage
 
-Make sure you remove any old PHP7.0 or PHP7.1 packages or at least, make sure they are not used by Apache and/or nginx. To disable PHP 7.0 or PHP7.1 in Apache, you can use:
+Make sure you remove any old PHP packages or at least, make sure they are not used by Apache and/or nginx. To ensure only PHP 7.3 is enabled in Apache, you can use:
 
 .. code-block:: bash
    
    sudo a2dismod php7.0
    sudo a2dismod php7.1
-   sudo a2enmod php7.2
+   sudo a2dismod php7.2
+   sudo a2enmod php7.3
    sudo service apache2 restart
 
 This assumes you run Apache and your OS package manager can handle multiple PHP versions (not all of them do this). Other commands can be found using a search engine.

--- a/docs/support/faq.rst
+++ b/docs/support/faq.rst
@@ -13,7 +13,7 @@ General questions
 So what is this thing really?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Firefly III is a web application written in PHP 7.2 with a database behind it that can be the tool you use to manage your personal finances. For more information, please read the :ref:`full description <introduction>`.
+Firefly III is a web application written in PHP 7.3 with a database behind it that can be the tool you use to manage your personal finances. For more information, please read the :ref:`full description <introduction>`.
 
 Can I try it first?
 ~~~~~~~~~~~~~~~~~~~
@@ -82,7 +82,7 @@ The following snippet might help:
          include snippets/fastcgi-php.conf;
          fastcgi_param SCRIPT_FILENAME $request_filename;
          fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
-         fastcgi_pass unix:/run/php/php7.2-fpm.sock;
+         fastcgi_pass unix:/run/php/php7.3-fpm.sock;
       }
    }
    
@@ -176,7 +176,7 @@ Answer be here
 Can I use it on PHP 5.x?
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-No. Most code has been written specifically for PHP 7.2 and higher.
+No. Most code has been written specifically for PHP 7.3 and higher.
 
 It is very slow on my server?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -196,7 +196,7 @@ Ensure with `dpkg-reconfigure locales` that the language you want to use is inst
 I get 'Unexpected question mark'?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Firefly III requires PHP 7.2 or higher.
+Firefly III requires PHP 7.3 or higher.
 
 I get 'BCMath' errors?
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This updates the docs to mention PHP 7.3.

The line `amazon-linux-extras install -y lamp-mariadb10.2-php7.2 php7.2` in the `hosted.rst` remains unchanged, as there seems to be no package to easily install a LAMP stack with PHP7.3 on AWS at the moment. This needs to be looked into more deeply or even just replaced with a link to Google (as currently with the LAMP stacks for Ubuntu / Raspberry etc.).