### PR TITLE
Fix typo in link to Atlassian JIRA

### DIFF
--- a/new-docs/import/csv.md
+++ b/new-docs/import/csv.md
@@ -1,6 +1,6 @@
 # Import CSV files
 
-Firefly III can import data from CSV files. It uses a very clever system inspired by [Atlassian JIRA](https://www.atlassian.com/software/jira>) to do so.
+Firefly III can import data from CSV files. It uses a very clever system inspired by [Atlassian JIRA](https://www.atlassian.com/software/jira) to do so.
 
 Before you continue reading the "how to" below, check out the **best practices** at the bottom of this page as well!
 


### PR DESCRIPTION
Minor fix of a typo in the link to Atlassian JIRA (which had a superfluous `>` in it).

Btw, thanks for an awesome-looking piece of software and all the hard work on it!