### PR TITLE
Suggest a simpler password generator

### DIFF
--- a/new-docs/installation/docker.md
+++ b/new-docs/installation/docker.md
@@ -34,7 +34,7 @@ docker volume create firefly_iii_upload
 
 ### Start the container
 
-Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of *exactly* 32 characters. You can generate such key with a command like: `head /dev/urandom | LANG=C tr -dc 'A-Za-z0-9' | head -c 32`.
+Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of *exactly* 32 characters. You can generate such a key with the following command: `head /dev/urandom | LANG=C tr -dc 'A-Za-z0-9' | head -c 32`.
 
 ```
 docker run -d \

--- a/new-docs/installation/docker.md
+++ b/new-docs/installation/docker.md
@@ -34,7 +34,7 @@ docker volume create firefly_iii_upload
 
 ### Start the container
 
-Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of *exactly* 32 characters. You can generate such an `APP_KEY` by using Laravel Artisan CLI: `php artisan key:generate --show`.
+Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of *exactly* 32 characters. You can generate such key with a command like: `head /dev/urandom | LANG=C tr -dc 'A-Za-z0-9' | head -c 32`.
 
 ```
 docker run -d \


### PR DESCRIPTION
Those who aren't PHP developers (more specifically Laravel developers) are unlikely to have artisan installed. Suggest a generation method based on basic utilities more or less any Unix machine will have installed.

This method is tested on both Linux and macOS (eg GNU and BSD coreutils).

The `LANG=C` is required for `tr` to prevent `Illegal byte sequence` errors if the user's locale is UTF-8.

Theoretically, this process might not generate enough data to create a 32 character ASCII password. But the chance of urandom output up to the 10th \n not including 32 alphanumeric characters is miniscule. The fewest I've seen is 60 after ~1 mil iterations.