### PR TITLE
Update self_hosted.md for PHP 7.4 requirement

### DIFF
--- a/new-docs/installation/self_hosted.md
+++ b/new-docs/installation/self_hosted.md
@@ -4,7 +4,7 @@ If you have your own (virtual) web server you can use this guide to install Fire
 
 ## Ingredients
 
-You need a working LAMP, LEMP or WAMP stack. If you don't have one, search the web to find out how to get one. Make sure you're running PHP 7.3. There are many tutorials that will help you install one. Here are some Google queries to help you.
+You need a working LAMP, LEMP or WAMP stack. If you don't have one, search the web to find out how to get one. Make sure you're running PHP 7.4. There are many tutorials that will help you install one. Here are some Google queries to help you.
 
 1. [Install a LAMP stack with PHP 7.3](https://www.google.com/search?q=lamp+stack+php+7.3)
 2. [Upgrade Ubuntu PHP 7.3](https://www.google.com/search?q=upgrade+ubuntu+php+7.3)


### PR DESCRIPTION
As per the [release notes for version `5.3.0`](https://github.com/firefly-iii/firefly-iii/releases/tag/5.3.0), PHP 7.4 is required to be used for firefly.

Fixes issue # (if relevant)

Changes in this pull request:

- Changing self-hosted docs to tell users that PHP 7.4 is now required.

@JC5
