### PR TITLE
Corrected docker documentation (architecture and product names)

### DIFF
--- a/new-docs/installation/docker.md
+++ b/new-docs/installation/docker.md
@@ -24,7 +24,7 @@ Firefly III has several Docker tags. The instructions always assume `jc5x/firefl
 * `jc5x/firefly-iii:release-x.x.x`. These are version specific tags and will include alpha, beta and stable releases.
 * `jc5x/firefly-iii:develop`. Always the latest develop image. Maybe unstable.
 
-All Docker tags are built for ARMv7, ARM64 and AMD64. AMDv6 is not included, so these images will *not* work on the Raspberry Pi Zero, Raspberry Pi 1 (A+B) or Rasberry Compute Module.
+All Docker tags are built for ARMv7, ARM64 and AMD64. ARMv6 is not included, so these images will *not* work on the Raspberry Pi Zero, Raspberry Pi 1 (A+B) or Raspberry Pi Compute Module.
 
 ## Straight from Docker Hub
 


### PR DESCRIPTION
Contacted James (via email) with documentation changes

Changes in this pull request:

- Documentation fixes on the docker.md page (arch: AMDv6 → ARMv6; Rasberry Compute Module → Raspberry Pi Compute Module

@JC5
