### PR TITLE
fix: changed link to csv importer doc

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,7 +8,7 @@ The [main documentation](firefly-iii) for Firefly III.
 
 ## CSV Importer
 
-Since this is by far the most used tool, [the docs](csv-importer) are separate from the others.
+Since this is by far the most used tool, [the docs](csv) are separate from the others.
 
 ## Other data importers
 


### PR DESCRIPTION
The link towards the csv importer docs on the index page pointed to the path `/csv-importer` but the csv docs are hosted on `/csv`

https://csv-docs.firefly-iii.org/
https://csv-docs.firefly-iii.org/csv/

~Fixes issue # (if relevant)~

Changes in this pull request:

- changed link towards the csv importer docs from /csv-importer to /csv as the former results in a 404 

@JC5
