### PR TITLE
Added documentation for AUTHENTICATION_GUARD customizations

### DIFF
--- a/docs/docs/firefly-iii/advanced-installation/authentication.md
+++ b/docs/docs/firefly-iii/advanced-installation/authentication.md
@@ -40,6 +40,8 @@ So if you use this authentication method make sure there is NO way *around* the 
 
 ### The guard header was unexpectedly empty
 
+As a troubleshooting step, try setting the `AUTHENTICATION_GUARD_HEADER` environment variable to `HTTP_REMOTE_USER`.  If this doesn't work, unset the `AUTHENTICATION_GUARD_HEADER` environment variable and make the change below.
+
 Make sure that the header is forwarded to Firefly III. For example, add the following lines to `public/.htaccess`.
 
 ```
@@ -48,6 +50,12 @@ Make sure that the header is forwarded to Firefly III. For example, add the foll
 ```
 
 This is less than optimal when you're using the Docker image but if the header is sent to your reverse proxy and not to Firefly III directly, it may be necessary to make such a change.
+
+### Customizing remote user header
+
+If you are able to customize your authentication system to send a header other than `REMOTE_USER` to Firefly III, then set the `AUTHENTICATION_GUARD_HEADER` environment variable to the PHP name of that header.  For example, if the custom header is `FFIII-User`, then set `AUTHENTICATION_GUARD_HEADER` to `HTTP_FFIII_USER`.  Another benefit of using a custom header is that you do not need to mess with the `public/.htaccess` file as mentioned above.
+
+If the user's email address is also available through a different HTTP header, then set the `AUTHENTICATION_GUARD_EMAIL` environment variable to the PHP name of that yeader.  For example, if the custom header is `FFIII-Email`, then set `AUTHENTICATION_GUARD_EMAIL` to `HTTP_FFIII_EMAIL`
 
 ## LDAP
 


### PR DESCRIPTION
After spending a few hours today trying to get Firefly to work with my existing KeyCloak / Vouch-Proxy authentication, I found that you could simply set the `AUTHENTICATION_GUARD_HEADER` and `AUTHENTICATION_GUARD_EMAIL` environment variables to whatever custom HTTP header you want, and with that I am officially a Firefly III user.  Additionally, I believe the `AUTHENTICATION_GUARD_HEADER` entirely removes the need to customize `.htaccess` file mentioned in the docs, so I changed that section but did not remove the `.htaccess` customization in case it's still useful to someone.  I will not be offended one bit if you want to tweak my wording, your docs are very clear and well-written, but I think it's important to expose these configuration options as they were the key to solving my problem.

Fixes issue # (if relevant)

Changes in this pull request:

Changed authentication.md "The guard header was unexpectedly empty" to include a troubleshooting step that does not require modification of static files within Docker image
Added authentication.md "Customizing remote user header" to add documentation about `AUTHENTICATION_GUARD_HEADER` and `AUTHENTICATION_GUARD_EMAIL`

@JC5
