### PR TITLE
Update docker commands

### DIFF
--- a/docs/docs/firefly-iii/advanced-installation/cron.md
+++ b/docs/docs/firefly-iii/advanced-installation/cron.md
@@ -160,7 +160,7 @@ $(docker container ls -a -f name=firefly --format="{{.ID}}")
 Here's an example:
 
 ```
-docker create --name=Firefly-Cronjob alpine sh -c "echo \"0 3 * * * wget <Firefly III URL>/api/v1/cron/<TOKEN>\" | crontab - && crond -f -L /dev/stdout"
+docker create --name=Firefly-Cronjob alpine sh -c "echo \"0 3 * * * wget -qO- <Firefly III URL>/api/v1/cron/<TOKEN>\" | crontab - && crond -f -L /dev/stdout"
 ```
 
 Write your Firefly III URL in the place of `<Firefly III URL>` and put your command line token in the place of `<TOKEN>`. Both are can be found in your profile.
@@ -170,7 +170,7 @@ Write your Firefly III URL in the place of `<Firefly III URL>` and put your comm
 ```
 cron:
   image: alpine
-  command: sh -c "echo \"0 3 * * * wget https://<Firefly III URL>/api/v1/cron/<TOKEN>\" | crontab - && crond -f -L /dev/stdout"
+  command: sh -c "echo \"0 3 * * * wget -qO- https://<Firefly III URL>/api/v1/cron/<TOKEN>\" | crontab - && crond -f -L /dev/stdout"
 ```
 
 Write your Firefly III URL in the place of `<Firefly III URL>` and put your command line token in the place of `<TOKEN>`. Both are can be found in your profile.


### PR DESCRIPTION
Fixes issue # (if relevant)
- The execution of the wget command in the docker container raises an error. This is due to the output of the wget command being written to a file named like `<TOKEN>`. After the first execution it tries to write the output to that same file which rasises the following error: `wget: can't open <TOKEN>: File exists`

Changes in this pull request:

- Add `-qO-` flag to wget command. This simply prevents the output of the wget from being written to a file.

@JC5
