### PR TITLE
Illegal byte sequence error, fixed

### DIFF
--- a/docs/docs/firefly-iii/installation/docker.md
+++ b/docs/docs/firefly-iii/installation/docker.md
@@ -36,7 +36,7 @@ docker volume create firefly_iii_upload
 
 ### Start the container
 
-Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of _exactly_ 32 characters. You can generate such a key with the following command: `head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 32`.
+Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of _exactly_ 32 characters. You can generate such a key with the following command: `head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 32 && echo`.
 
 ```text
 docker run -d \

--- a/docs/docs/firefly-iii/installation/docker.md
+++ b/docs/docs/firefly-iii/installation/docker.md
@@ -36,7 +36,7 @@ docker volume create firefly_iii_upload
 
 ### Start the container
 
-Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of _exactly_ 32 characters. You can generate such a key with the following command: `head /dev/urandom | LANG=C tr -dc 'A-Za-z0-9' | head -c 32`.
+Run this Docker command to start the Firefly III container. Make sure that you edit the environment variables to match your own database. You should really change the `APP_KEY` as well. It should be a random string of _exactly_ 32 characters. You can generate such a key with the following command: `head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 32`.
 
 ```text
 docker run -d \


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:

- Changes `LC_LANG` to `LC_ALL` on  the 32 char string generation command so that it works on OSX, see behaviour on Big Sur:

```
$ head /dev/urandom | LANG=C tr -dc 'A-Za-z0-9' | head -c 32
tr: Illegal byte sequence
$ head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 32
XP2H1Ss8QUOf7cgDLdRopX8y03sQkCmY$
$ head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 32 && echo
cBSINxJsVtnK2TZfCJzCDaGzdHwJZGXc
$
```

References:  https://unix.stackexchange.com/questions/45404/why-cant-tr-read-from-dev-urandom-on-osx

@JC5
