### PR TITLE
Correct nordigen-importer composer command

### DIFF
--- a/docs/docs/other-data-importers/install/self_hosted.md
+++ b/docs/docs/other-data-importers/install/self_hosted.md
@@ -56,7 +56,7 @@ composer create-project firefly-iii/spectre-importer --no-dev --prefer-dist spec
 ### Nordigen
 
 ```bash
-composer create-project firefly-iii/nordigen-importer --no-dev --prefer-dist spectre-importer <latest>
+composer create-project firefly-iii/nordigen-importer --no-dev --prefer-dist nordigen-importer <latest>
 ```
 
 ### YNAB


### PR DESCRIPTION
Just a small issue in the nordigen composer install command, where you forgot to change the directory it installs to.

Changes in this pull request:

- Change folder nordigen-importer installs to

@JC5
