### PR TITLE
Updated docker-compose example for fidi

### DIFF
--- a/docs/docs/data-importer/install/docker.md
+++ b/docs/docs/data-importer/install/docker.md
@@ -71,8 +71,6 @@ services:
   fidi:
     image: fireflyiii/data-importer:latest
     restart: always
-    volumes:
-      - fidi_upload:/var/www/html/storage/upload
     env_file: .fidi.env
     ports:
       - 8081:8080
@@ -81,7 +79,6 @@ services:
 volumes:
   firefly_iii_upload:
   firefly_iii_db:
-  fidi_upload:
 ```
 
 

--- a/docs/docs/data-importer/install/docker.md
+++ b/docs/docs/data-importer/install/docker.md
@@ -70,6 +70,9 @@ services:
       - firefly_iii_db:/var/lib/mysql
   fidi:
     image: fireflyiii/data-importer:latest
+    restart: always
+    volumes:
+      - fidi_upload:/var/www/html/storage/upload
     env_file: .fidi.env
     ports:
       - 8081:8080
@@ -78,6 +81,7 @@ services:
 volumes:
   firefly_iii_upload:
   firefly_iii_db:
+  fidi_upload:
 ```
 
 


### PR DESCRIPTION
Updated the docker compose example for fidi to include a volume and restart option.

Fixes issue # (if relevant)
I noticed that FIDI created a container volume when started. So I updated the docker compose to show this. Assuming this was an intentional decision for the image.


Changes in this pull request:

- Updated docker compose to show a volume is created for FIDI
- Updated the docker compose to add a restart option for FIDI to keep it consistent with app example.
- 

@JC5
