### PR TITLE
fix: fixing form field name for importing via POST

### DIFF
--- a/docs/docs/data-importer/usage/post.md
+++ b/docs/docs/data-importer/usage/post.md
@@ -31,7 +31,7 @@ The CSV file and the JSON file must both be uploaded, after which the result wil
 curl --location --request POST 'https://fidi/autoupload?secret=YOURSECRETHERE' \
 --header 'Accept: application/json' \
 --header 'Authorization: Bearer ey....' \
---form 'csv=@"/local/path/to/csv.csv"' \
+--form 'importable=@"/local/path/to/csv.csv"' \
 --form 'json=@"/local/path/to/json.json"'
 ```
 


### PR DESCRIPTION
Changes in this pull request:

It looks like the documentation was incorrect about the name of the form field for the import. Using csv throws the Type Error `file_get_contents(): Argument #1 ($filename) must be of type string, null given`

@JC5
