### PR TITLE
Add hint for remote user authentication

### DIFF
--- a/docs/docs/data-importer/install/configure.md
+++ b/docs/docs/data-importer/install/configure.md
@@ -26,6 +26,9 @@ To authenticate with Firefly III you must set ONE the following variables:
 !!! important
     A Docker installation will *never* be able to connect a Firefly III installation located at `http://localhost` or `http://127.0.0.1` because this address refers to the Docker container itself, and not Firefly III.
 
+!!! important
+    If you are using an [external identity provider](https://docs.firefly-iii.org/firefly-iii/advanced-installation/authentication/#remote-user) to authenticate with Firefly, you must use a personal access token to connect your FIDI with Firefly. It is not possible to use a client ID in that case.
+
 ## Configure Nordigen
 
 To configure Nordigen, set the following variables. This is necessary if you wish to connect to your bank through Nordigen.


### PR DESCRIPTION
As discussed in https://github.com/firefly-iii/firefly-iii/issues/6831#issuecomment-1396464868, when configuring Firefly with an external identity provider, FIDI can only user personal access tokens. With this commit, this information is added to the FIDI documentation.

@JC5
