### PR TITLE
Support using other ports in the nginx

### DIFF
--- a/docs/docs/firefly-iii/installation/docker.md
+++ b/docs/docs/firefly-iii/installation/docker.md
@@ -137,8 +137,8 @@ If you are using Nginx add the following to your location block:
 
 ```text
 proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header X-Forwarded-Host $host;
-proxy_set_header X-Forwarded-Server $host;
+proxy_set_header X-Forwarded-Host $http_host;
+proxy_set_header X-Forwarded-Server $http_host;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header Host $host;
 ```

--- a/docs/docs/firefly-iii/installation/docker.md
+++ b/docs/docs/firefly-iii/installation/docker.md
@@ -137,8 +137,9 @@ If you are using Nginx add the following to your location block:
 
 ```text
 proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header X-Forwarded-Host $http_host;
-proxy_set_header X-Forwarded-Server $http_host;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Server $host;
+proxy_set_header X-Forwarded-Port $server_port;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header Host $host;
 ```


### PR DESCRIPTION
Support using other ports in the nginx  then 80 for http and 443 for https

Fixes issue # (if relevant)

Changes in this pull request:
- nginx config for supporting other ports

@JC5
