### PR TITLE
Add Android app: Waterfly III

### DIFF
--- a/docs/docs/firefly-iii/more-information/3rdparty.md
+++ b/docs/docs/firefly-iii/more-information/3rdparty.md
@@ -40,6 +40,15 @@ Photuris III is an android app created by @emansih that connects to your Firefly
 - [Google Play Store](https://play.google.com/store/apps/details?id=xyz.hisname.fireflyiii)
 - [F-Droid store](https://f-droid.org/packages/xyz.hisname.fireflyiii/)
 
+### Waterfly III
+
+Waterfly III is an android app created by @dreautall that connects to your Firefly III installation.
+
+- [Credits](https://github.com/dreautall)
+- [Website and documentation](https://github.com/dreautall/waterfly-iii)
+- [Google Play Store](https://play.google.com/store/apps/details?id=com.dreautall.waterflyiii)
+- [F-Droid store](https://f-droid.org/en/packages/com.dreautall.waterflyiii/)
+
 ### OCR Firefly Mobile
 
 OCR Firefly Mobile is a little tool to help you enter transactions into the mobile app automatically.

--- a/docs/docs/firefly-iii/more-information/3rdparty.md
+++ b/docs/docs/firefly-iii/more-information/3rdparty.md
@@ -23,6 +23,14 @@ David built a tool to send you a monthly overview of your expenses by category.
 
 ## Mobile applications
 
+### Waterfly III
+
+Waterfly III is an android app created by @dreautall that connects to your Firefly III installation.
+
+- [Credits](https://github.com/dreautall)
+- [Website and documentation](https://github.com/dreautall/waterfly-iii)
+- [Google Play Store](https://play.google.com/store/apps/details?id=com.dreautall.waterflyiii)
+
 ### Firefly Personal Finance
 
 Firefly Personal Finance is an android app created by @mconway that connects to your Firefly III installation.
@@ -39,14 +47,6 @@ Photuris III is an android app created by @emansih that connects to your Firefly
 - [Website and documentation](https://github.com/emansih/FireflyMobile)
 - [Google Play Store](https://play.google.com/store/apps/details?id=xyz.hisname.fireflyiii)
 - [F-Droid store](https://f-droid.org/packages/xyz.hisname.fireflyiii/)
-
-### Waterfly III
-
-Waterfly III is an android app created by @dreautall that connects to your Firefly III installation.
-
-- [Credits](https://github.com/dreautall)
-- [Website and documentation](https://github.com/dreautall/waterfly-iii)
-- [Google Play Store](https://play.google.com/store/apps/details?id=com.dreautall.waterflyiii)
 
 ### OCR Firefly Mobile
 

--- a/docs/docs/firefly-iii/more-information/3rdparty.md
+++ b/docs/docs/firefly-iii/more-information/3rdparty.md
@@ -47,7 +47,6 @@ Waterfly III is an android app created by @dreautall that connects to your Firef
 - [Credits](https://github.com/dreautall)
 - [Website and documentation](https://github.com/dreautall/waterfly-iii)
 - [Google Play Store](https://play.google.com/store/apps/details?id=com.dreautall.waterflyiii)
-- [F-Droid store](https://f-droid.org/en/packages/com.dreautall.waterflyiii/)
 
 ### OCR Firefly Mobile
 


### PR DESCRIPTION
I created a flutter android app to use as a companion for Firefly: Waterfly III. Open-Source, ad-free, no trackers etc.

I hope it's okay in the place where I put it - below the other full-featured (but sadly not anymore updated) android apps & above the OCR companion app. If not, feel free to move lower as the "newest" app.

Thanks for the awesome software, and the quick bugfixes on the API issues I reported 😄 

@JC5
