### PR TITLE
Add firefly-iii-ai-categorize project to 3rdparty docs

### DIFF
--- a/docs/docs/firefly-iii/more-information/3rdparty.md
+++ b/docs/docs/firefly-iii/more-information/3rdparty.md
@@ -87,6 +87,13 @@ The PHP API library is a library developed by StanSoft.BG Ltd that allows you to
 - [Credits](https://github.com/StanSoftBG)
 - [Website](https://github.com/StanSoftBG/oauth2-firefly-iii)
 
+### AI Categorizer
+
+Firefly III AI Categorizer is a tool developed by @bahuma20 that allows you to automatically categorize your expenses for free by using OpenAI.
+
+- [Credits](https://github.com/bahuma20)
+- [Website](https://github.com/bahuma20/firefly-iii-ai-categorize)
+
 ### Telegram bot for Firefly III
 
 The Telegram bot for Firefly III can create transactions through Telegram.


### PR DESCRIPTION
Hey, i have created a tool that allows you to automatically categorize your expenses by using OpenAI.

It is triggered by a webhook and will generate a prompt, including all avaliable categories in Firefly-III plus the description and destination_name of the transaction, and send that to OpenAI.

Then it will set the category to this transaction.

Would be great if you could add it to your docs 🙂 

@JC5
