### PR TITLE
Fix typo in organizing.md

### DIFF
--- a/docs/docs/firefly-iii/financial-concepts/organizing.md
+++ b/docs/docs/firefly-iii/financial-concepts/organizing.md
@@ -79,7 +79,7 @@ Example: you have a monthly budget of 50 for clothes.
 
 You spend 125 in February.
 
-* March, the budget amount will be set to 25 (100 - 125)
+* March, the budget amount will be set to 25 (150 - 125)
 
 Just like the "fixed amount" auto-budget settings, these changes will happen on specific moments. This depends on the budget settings. If you spent way too much, twice the period's amount, the new period will be set to 1 (one).
 


### PR DESCRIPTION
Unless I'm mistaken this should add 50 (for the new month) to the already present 100 and remove 125 for the payment. According to the brackets we'd end up at -25.

Or if looked at the other way: Remove 125 from 100, resulting in -25, then add the 50 for the new month.

Changes in this pull request:

- Update number in explanation brackets to match previous month + configured budget

@JC5
