### PR TITLE
Adding note about v6 Heroku support

### DIFF
--- a/docs/docs/firefly-iii/installation/third-parties.md
+++ b/docs/docs/firefly-iii/installation/third-parties.md
@@ -10,6 +10,8 @@ Mariushosting.com wrote [an excellent guide](https://mariushosting.com/how-to-in
 
 Firefly III supports [Heroku](https://heroku.com/). You can [deploy Firefly III in Heroku](https://heroku.com/deploy?template=https://github.com/firefly-iii/firefly-iii/tree/main) after you register for an account.
 
+> As of version [v6.0.17](https://github.com/firefly-iii/firefly-iii/releases/tag/v6.0.16), support for Heroku has been removed
+
 ### Considerations when using Heroku
 
 Heroku uses what is called an "ephemeral file system" and it will not be able to store attachments. They will be deleted [every day](https://devcenter.heroku.com/articles/dynos#automatic-dyno-restarts). Don't use Firefly III on Heroku in combination with sensitive or rare file attachments.


### PR DESCRIPTION
Heroku support was dropped in commit [3ee5e9](https://github.com/firefly-iii/firefly-iii/commit/3ee5e9aa041c61d71c3e276097a2ba368348908f). Wanted to add a side note for any v6 users. 

On a side note, I'm interested in working on the support for Heroku with v6 if possible. Thanks for the product!

@JC5
