### PR TITLE
Data-Importer docs: specify that notifications are not sent from the UI

### DIFF
--- a/docs/docs/how-to/data-importer/advanced/notifications.md
+++ b/docs/docs/how-to/data-importer/advanced/notifications.md
@@ -1,6 +1,6 @@
 # How to set up notifications
 
-The data importer can email you the results of the import. This is useful for cron jobs.
+The data importer can email you the results of the import [if run from the CLI](../cli/). This is useful for cron jobs.
 
 In your `.env.example` file or using Docker environment variables, configure the data importer as follows:
 
@@ -21,6 +21,8 @@ MAIL_FROM_ADDRESS=noreply@example.com
 Update the settings to match your email configuration. The first thing you'll want to update is the `MAIL_MAILER`. The mail mailer indicates the system that is used for mailing. The data importer supports the following mail systems: smtp, sendmail, mailgun, mandrill, sparkpost and log.
 
 *Always* change the `MAIL_FROM_ADDRESS` address. If this is wrong, mail might never work!
+
+*Please note* that UI does not send import reports via email.
 
 ## log
 


### PR DESCRIPTION
As discussed in the relevant [thread](https://github.com/orgs/firefly-iii/discussions/8309), added a note in the docs to avoid others to ask the same question.
