### PR TITLE
Change Issue Redirect To Discussion Redirect

### DIFF
--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -25,7 +25,7 @@ More choices are in the menu.
 - You think a specific tutorial should be written, and you don't wish to write it.
 - You spotted inaccuracies, improper grammar, or spelling mistakes.
 
-Please open an [issue on GitHub](https://github.com/firefly-iii/firefly-iii/issues/new?assignees=&labels=&projects=&template=fr.yml). Your contributions are appreciated.
+Please start a [discussion](https://github.com/orgs/firefly-iii/discussions/new/choose). Your contributions are appreciated.
 
 ## Would you like to know more?
 


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:

- Modified docs/docs/tutorials/index.md line 28 to redirect users to the organization-wide discussion choice page, as well as changing "Please open an issue" to "Please start a discussion."

@JC5
