### PR TITLE
State that a Service API key is required for Spectre imports

### DIFF
--- a/docs/docs/how-to/data-importer/import/salt-edge.md
+++ b/docs/docs/how-to/data-importer/import/salt-edge.md
@@ -14,9 +14,14 @@ Please read and agree with all the terms that the company may present you with. 
 
 ## Salt Edge's Spectre API
 
-You can sign up for Salt Edge's services on [this page](https://www.saltedge.com/client_users/sign_up).
+You can sign up for Salt Edge's services [on this page](https://www.saltedge.com/client_users/sign_up).
 
 Your account will initially have a "pending" status. In order to get access to real banks, please request "test" access from your Client's dashboard main page and mention you’re a Firefly III user.
+
+An application API key needs to be created for the Data Importer, you can view the steps to do this [on this page](https://docs.saltedge.com/account_information/v5/#create-api-keys).
+
+!!! info "Required API key type"
+    A Service API key must be made, as an App API key blocks the use of the endpoints that the importer requires
 
 ### Limits
 


### PR DESCRIPTION
States the required API key type required to import data from the Spectre API, as referenced in issue firefly-iii/firefly-iii#8381

Changes in this pull request:
- Modified docs/docs/how-to/data-importer/import/salt-edge.md to explain how to create an application API key on Salt Edge and added a warning that a Service API key must be made.
- Also made hyperlinking consistent on line 17 with the rest of the document

@JC5
