### PR TITLE
fix: typo in piggy banks explaination

### DIFF
--- a/docs/docs/explanation/financial-concepts/piggy-banks.md
+++ b/docs/docs/explanation/financial-concepts/piggy-banks.md
@@ -8,7 +8,7 @@ If you want to buy something expensive, you might need to save for it. You can u
 
 ## Where are piggy banks stored?
 
-Piggy banks are stored under the `/pigg-banks`-page in Firefly III. Each piggy bank is tied to an asset account on which its money is saved. You may have a savings account with three piggy banks, for example.
+Piggy banks are stored under the `/piggy-banks`-page in Firefly III. Each piggy bank is tied to an asset account on which its money is saved. You may have a savings account with three piggy banks, for example.
 
 ## And then what?
 


### PR DESCRIPTION
I came across a small typo when perusing the documentation whilst setting up a Firefly III instance. Thanks for all the hard work you put in!

 
Changes in this pull request:

- Correct typo in piggy banks explanation page.

@JC5
