### PR TITLE
Update nordigen link to gocardless

### DIFF
--- a/docs/docs/explanation/data-importer/about/gocardless-salt-edge.md
+++ b/docs/docs/explanation/data-importer/about/gocardless-salt-edge.md
@@ -40,6 +40,6 @@ You can sign up for the GoCardless API on [their website](https://bankaccountdat
 3. Follow the instructions
 4. Profit!
 
-GoCardless supports [many PSD2-compliant banks in the EU and the UK](https://nordigen.com/en/coverage/), making it an alternative for Salt Edge's Spectre API, if you happen to live in these regions.
+GoCardless supports [many PSD2-compliant banks in the EU and the UK](https://gocardless.com/bank-account-data/coverage/), making it an alternative for Salt Edge's Spectre API, if you happen to live in these regions.
 
 Access to the GoCardless API is limited to raw data only, which means you may have to do data cleanup yourself. You can use Firefly III [rules](../../../how-to/firefly-iii/features/rules.md) or build something yourself.


### PR DESCRIPTION
The link to the available bank connections for GoCardless is still pointing to a Nordigen URL. Changed that to the corresponding GoCardless URL.