### PR TITLE
Document commands as executed by user www-data

### DIFF
--- a/docs/docs/how-to/firefly-iii/installation/self-managed.md
+++ b/docs/docs/how-to/firefly-iii/installation/self-managed.md
@@ -110,6 +110,12 @@ In the directory where you just unzipped Firefly III you will find a `.env.examp
 cp .env.example .env
 ```
 
+If your web root is owned by `www-data`, then use this command:
+
+```bash
+sudo -u www-data cp .env.example .env
+```
+
 Open this file using your favorite editor. There are instructions what to do in this file.
 
 Make sure you configure at least the database. For SQLite, you must drop all the configuration except `DB_CONNECTION=sqlite`.
@@ -126,6 +132,14 @@ cd /var/www/firefly-iii
 touch ./storage/database/database.sqlite
 ```
 
+If your web root is owned by `www-data`, then use this command:
+
+```bash
+# the directory may be different on your system:
+cd /var/www/firefly-iii
+sudo -u www-data touch ./storage/database/database.sqlite
+```
+
 Either way, in all cases, run these commands to initialize the database:
 
 ```bash
@@ -133,6 +147,15 @@ php artisan firefly-iii:upgrade-database
 php artisan firefly-iii:correct-database
 php artisan firefly-iii:report-integrity
 php artisan firefly-iii:laravel-passport-keys
+```
+
+Similarly, if your web root is owned by `www-data`, then execute these commands instead to ensure that all the files in your web-root have the same permissions:
+
+```bash
+sudo -u www-data php artisan firefly-iii:upgrade-database
+sudo -u www-data php artisan firefly-iii:correct-database
+sudo -u www-data php artisan firefly-iii:report-integrity
+sudo -u www-data php artisan firefly-iii:laravel-passport-keys
 ```
 
 Now you should be able to visit [http://localhost/firefly-iii/public](http://localhost/firefly-iii/public) and see Firefly III.


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue https://github.com/firefly-iii/firefly-iii/issues/10644.

This pull request updates the Firefly III self-managed installation guide to include instructions for systems where the web root is owned by `www-data`. These changes ensure proper file permissions and ownership during setup.

### Updates to installation instructions:

* Added a command to copy the `.env.example` file as `.env` using `sudo -u www-data` for cases where the web root is owned by `www-data`. (`docs/docs/how-to/firefly-iii/installation/self-managed.md`, [docs/docs/how-to/firefly-iii/installation/self-managed.mdR113-R118](diffhunk://#diff-f2ec6006cd0b0566556c609ba6fa4371537483a4ff0ff4403198bfc890898c3cR113-R118))
* Included a command to create the SQLite database file using `sudo -u www-data`, along with a note about navigating to the appropriate directory. (`docs/docs/how-to/firefly-iii/installation/self-managed.md`, [docs/docs/how-to/firefly-iii/installation/self-managed.mdR135-R142](diffhunk://#diff-f2ec6006cd0b0566556c609ba6fa4371537483a4ff0ff4403198bfc890898c3cR135-R142))

### Updates to database initialization commands:

* Added alternative commands to initialize the database (`upgrade-database`, `correct-database`, `report-integrity`, and `laravel-passport-keys`) using `sudo -u www-data` for consistent file permissions in the web root. (`docs/docs/how-to/firefly-iii/installation/self-managed.md`, [docs/docs/how-to/firefly-iii/installation/self-managed.mdR152-R160](diffhunk://#diff-f2ec6006cd0b0566556c609ba6fa4371537483a4ff0ff4403198bfc890898c3cR152-R160))