### PR TITLE
Add fireflyiii-mcp as MCP server to apps

### DIFF
--- a/docs/docs/references/firefly-iii/third-parties/apps.md
+++ b/docs/docs/references/firefly-iii/third-parties/apps.md
@@ -98,6 +98,14 @@ A client-side Progressive Web App for recording and tracking transactions on you
 
 ## Bots and tools
 
+### fireflyiii-mcp
+
+A TypeScript MCP server for Firefly III with 140 tools across 14 groups (accounts, transactions, budgets, categories, bills, piggy banks, rules, recurring transactions, attachments, currencies, exports, object groups, transaction links, and reports). Supports full CRUD, Personal Access Token and OAuth 2.0 authentication, and tool filtering via presets or group selection.
+
+- [Credits](https://github.com/daften)
+- [Repository](https://github.com/daften/fireflyiii-mcp)
+- [npm package](https://www.npmjs.com/package/@daften/fireflyiii-mcp)
+
 ### A TypeScript SDK
 
 A TypeScript SDK for Firefly III, automatically generated from the official OpenAPI specification.


### PR DESCRIPTION
I developed an MCP server that encompasses all tools (140 tools in total) with full CRUD. It's created using typescript, has full test coverage.
For authentication, it supports PAT (for stdio) and OAuth for HTTP. And it has an NPM package and a docker container. The docker container is targeted at HTTP deployment allowing full secure authentication using OAuth (if set up correctly of course).