### PR TITLE
Add Entropy for Firefly III section to apps.md

### DIFF
--- a/docs/docs/references/firefly-iii/third-parties/apps.md
+++ b/docs/docs/references/firefly-iii/third-parties/apps.md
@@ -202,6 +202,14 @@ Yemzikk forked and enhanced this project with some cool new features:
 
 - [Enhanced version by Yemzikk](https://github.com/yemzikk/firefly-iii-email-summary)
 
+### FF3 Entropy
+
+A read-only forecast view for Firefly III that flags recurring transactions that were due but never turned up.
+
+- [Credits](https://github.com/4242labs)
+- [Source](https://github.com/4242labs/ff3-entropy)
+- [Demo](https://ff3-entropy.42labs.io)
+
 ## Import tools
 
 All import related tools are listed [on the page on importing data](../../data-importer/third-party-tools.md).

--- a/docs/docs/references/firefly-iii/third-parties/apps.md
+++ b/docs/docs/references/firefly-iii/third-parties/apps.md
@@ -202,13 +202,13 @@ Yemzikk forked and enhanced this project with some cool new features:
 
 - [Enhanced version by Yemzikk](https://github.com/yemzikk/firefly-iii-email-summary)
 
-### FF3 Entropy
+### Entropy for Firefly III 
 
 A read-only forecast view for Firefly III that flags recurring transactions that were due but never turned up.
 
 - [Credits](https://github.com/4242labs)
-- [Source](https://github.com/4242labs/ff3-entropy)
-- [Demo](https://ff3-entropy.42labs.io)
+- [Source](https://github.com/4242labs/ff3e)
+- [Demo](https://ff3e.42labs.io)
 
 ## Import tools
 


### PR DESCRIPTION
I'm adding "FF3 Entropy", a read-only forecast view for Firefly III that flags recurring transactions that were due but never turned up.

- [Credits](https://github.com/4242labs)
- [Source](https://github.com/4242labs/ff3-entropy)
- [Demo](https://ff3-entropy.42labs.io)