### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/docs/docs/references/firefly-iii/third-parties/host.md
+++ b/docs/docs/references/firefly-iii/third-parties/host.md
@@ -3,6 +3,12 @@
 !!! warning These tools are unsupported
     I can't always offer support for these platforms. There are a lot of them. Feel free to start a [discussion](https://github.com/orgs/firefly-iii/discussions), but you may have to do some exploration to get your issue resolved.
 
+## Zenith
+
+Firefly III is featured on [Zenith](https://zenith.hosting/host/firefly-iii), which runs the instance for you in one click. Storage, backups, email and a free subdomain are included, and a share of every subscription goes back to Firefly III.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/firefly-iii)
+
 ## AMPPS
 
 Firefly III is featured in [AMPPS](https://www.ampps.com/). You can download AMPPS for Windows, Linux and Mac and Firefly III will be available as a package there.


### PR DESCRIPTION
#### Reference issues and PRs

None. This is a small addition to an existing reference page, happy to open a discussion first if you would prefer that.

#### What does this implement/fix? Explain your changes.

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Firefly III to our marketplace, so this PR adds a section for it to `references/firefly-iii/third-parties/host.md`, alongside the other third parties already listed there (links to https://zenith.hosting/host/firefly-iii).

it follows the existing section format on that page and includes the "Deploy with Zenith" badge image. i put it at the top of the list, but the page looks roughly alphabetical, so say the word and i will move it down between Unraid and Yunohost instead.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://docs.firefly-iii.org/explanation/support/#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?

The page carries the "unsupported" warning at the top, which applies here too. If you would rather keep this page for app-store style packages only, close it and no hard feelings.

@JC5


